### PR TITLE
Update prettier dep and quoted glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint": "^3.13.1",
     "jpm": "^1.2.2",
     "node-sass": "^4.1.1",
-    "prettier": "0.0.9",
+    "prettier": "^0.11.0",
     "sass-loader": "^4.1.1",
     "style-loader": "^0.13.1",
     "webpack": "^1.14.0",
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "webpack",
     "watch": "webpack",
-    "prettier": "prettier --single-quote --write src/**/*.js webpack.config.js",
+    "prettier": "prettier --single-quote --write 'src/**/*.js' webpack.config.js",
     "lint": "eslint ."
   }
 }


### PR DESCRIPTION
Quoting glob for `prettier` npm run script. Apparently it was only running on a subset of files before (ref https://github.com/jlongster/prettier/issues/451).

### Before:
```sh
$ npm run prettier

> pulse@0.1.0 prettier /Users/pdehaan/dev/github/mozilla/pulse
> prettier --single-quote --write src/**/*.js webpack.config.js

src/lib/log.js
src/webextension/background.js
webpack.config.js
```

### After:
```sh
$ npm run prettier

> pulse@0.1.0 prettier /Users/pdehaan/dev/github/mozilla/pulse
> prettier --single-quote --write 'src/**/*.js' webpack.config.js

webpack.config.js
src/index.js
src/lib/log.js
src/webextension/background.js
src/webextension/survey/lib/open.js
src/webextension/survey/survey.js
```

Also updated `prettier` dependency version and added semver range operator, because why not...