### PR TITLE
Passes tab and window objects to measurements.

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,13 @@
+import tabs from 'sdk/tabs';
+
+// Passed numeric tab and window IDs, returns an object containing the full Tab
+// and BrowserWindow objects from which the report was intitiated. The
+// retrieval methods are horribly inefficient, but it doesn't appear to be
+// possible to look up a tab or window from its ID.
+export const getTab = (tabId, windowId) => {
+  for (let tab of tabs) {
+    if (tab.id === `-${tabId}-${windowId}`) {
+      return { tab, window: tab.window };
+    }
+  }
+};

--- a/src/measurements/index.js
+++ b/src/measurements/index.js
@@ -1,12 +1,17 @@
 import TelemetryId from './telemetry-id';
+import { getTab } from '../lib/utils';
 
-const measurements = [ TelemetryId ];
+const MEASUREMENTS = [ TelemetryId ];
 
+// Passed the output from the survey, augments that data with each measurment
+// in MEASUREMENTS and returns a promise resolving to a Map containing the full
+// payload, ready for submission to telemetry.
 export default survey => {
+  const { tab, window } = getTab(survey.get('tab'), survey.get('window'));
   return new Promise((resolve, reject) => {
     Promise
       .all(
-        measurements.map(Measure => new Measure(null, null, survey).getValue())
+        MEASUREMENTS.map(Measure => new Measure(tab, window, survey).getValue())
       )
       .then(data => resolve(new Map([ ...survey, ...data ])))
       .catch(err => reject(err));


### PR DESCRIPTION
Factored this out of #68, so I can work on other bugs that require this bit.

I'll merge this one as soon as CI finishes.