### PR TITLE
Minify production builds (closes #103).

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-loader": "^6.2.10",
     "babel-preset-latest": "^6.16.0",
     "babel-preset-react": "^6.22.0",
+    "babili-webpack-plugin": "0.0.10",
     "classnames": "^2.2.5",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,13 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const AfterBuildPlugin = require('./lib/webpack-after-build');
+const BabiliPlugin = require('babili-webpack-plugin');
 const webpack = require('webpack');
 const { exec, mkdir } = require('shelljs');
 
+const PRODUCTION = process.env.NODE_ENV && process.env.NODE_ENV === 'production';
 const WATCH_MODE = process.argv.includes('--watch');
 
-module.exports = {
+const config = {
   output: { path: 'build', filename: '[name].js' },
   // Separate entry points for the SDK add-on, WebExtension background script,
   // and survey (used both as a WebExtension popup and as a navigable page).
@@ -73,3 +75,9 @@ module.exports = {
     })
   ]
 };
+
+if (PRODUCTION) {
+  config.plugins.push(new BabiliPlugin());
+}
+
+module.exports = config;


### PR DESCRIPTION
Some of our libraries use ESfuture features that aren't supported by Webpack's UglifyJS plugin, so instead I'm using a minifier that does.

Note: this only affects files that are processed by Webpack, namely (in the build extension):

- index.js
- webextension/background.js
- webextension/survey/index.js