### PR TITLE
Builds addon during CI (closes #81).

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,3 +5,4 @@ machine:
 test:
   override:
     - npm run lint
+    - npm run build

--- a/lib/webpack-error.js
+++ b/lib/webpack-error.js
@@ -1,0 +1,11 @@
+module.exports = class ThrowErrorPlugin {
+  apply (compiler) {
+    compiler.plugin('done', stats => {
+      if (stats.compilation.errors && stats.compilation.errors.length) {
+        // eslint-disable-next-line no-console
+        console.error(stats.compilation.errors);
+        process.exit(1);
+      }
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   "dependencies": {
     "babel-core": "^6.21.0",
     "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
     "babel-preset-latest": "^6.16.0",
-    "babel-preset-react": "^6.22.0",
+    "babel-preset-react": "^6.23.0",
     "babili-webpack-plugin": "0.0.10",
     "classnames": "^2.2.5",
     "copy-webpack-plugin": "^4.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,10 @@
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const AfterBuildPlugin = require('./lib/webpack-after-build');
-const BabiliPlugin = require('babili-webpack-plugin');
 const webpack = require('webpack');
 const { exec, mkdir } = require('shelljs');
+
+const AfterBuildPlugin = require('./lib/webpack-after-build');
+const BabiliPlugin = require('babili-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const ThrowErrorPlugin = require('./lib/webpack-error');
 
 const PRODUCTION = process.env.NODE_ENV && process.env.NODE_ENV === 'production';
 const WATCH_MODE = process.argv.includes('--watch');
@@ -31,13 +33,13 @@ const config = {
         test: /\.js$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
-        query: { presets: [ 'es2015' ] }
+        query: { presets: [ 'babel-preset-es2015' ] }
       },
       {
         test: /\.jsx$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
-        query: { presets: [ 'es2015', 'react' ] }
+        query: { presets: [ 'babel-preset-es2015', 'babel-preset-react' ] }
       },
       // Appropriately precompile SCSS files.
       { test: /\.scss$/, loaders: [ 'style', 'css', 'sass' ] },
@@ -53,6 +55,7 @@ const config = {
     ]
   },
   plugins: [
+    new ThrowErrorPlugin(),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': `"${process.env.NODE_ENV || 'dev'}"`
     }),


### PR DESCRIPTION
This PR does four things:

1) Ensures that the correct exit code is returned when Webpack builds fail ([example](https://circleci.com/gh/chuckharmston/pulse/112)).
2) Runs the build in CI.
3) Adds the es2015 preset to the package dependencies.
4) Refers to presets by full NPM package name.