### PR TITLE
Randomly prompt users for feedback (closes #14).

### DIFF
--- a/src/data/sitename.js
+++ b/src/data/sitename.js
@@ -1,0 +1,7 @@
+self.port.on('get-sitename', () => {
+  const og_sitename = document.querySelector('meta[property="og:site_name"]');
+  self.port.emit(
+    'send-sitename',
+    og_sitename ? og_sitename.content : window.location.hostname
+  );
+});

--- a/src/lib/notify.js
+++ b/src/lib/notify.js
@@ -1,0 +1,221 @@
+import uuid from 'uuid';
+
+import { Services } from 'resource://gre/modules/Services.jsm';
+import Uri from 'urijs';
+import { data } from 'sdk/self';
+import { storage } from 'sdk/simple-storage';
+import tabs from 'sdk/tabs';
+import { getMostRecentBrowserWindow } from 'sdk/window/utils';
+
+import Logger from './log';
+import sendEvent from './metrics';
+
+const logger = new Logger(
+  'sdk.lib.notify',
+  getMostRecentBrowserWindow().console
+);
+
+class BaseElement {
+  getWindow() {
+    return Services.wm.getMostRecentWindow('navigator:browser');
+  }
+}
+
+class RatingStar extends BaseElement {
+  constructor(val, cb) {
+    super(...arguments);
+    this.element = this.render(val, cb);
+  }
+
+  handleClick(evt, cb) {
+    cb(evt.target.getAttribute('data-score'));
+  }
+
+  render(val, cb) {
+    const win = this.getWindow();
+    const elem = win.document.createElement('toolbarbutton');
+    elem.classList.add('plain', 'star-x');
+    elem.id = `star-${val}`;
+    elem.setAttribute('data-score', val);
+    elem.addEventListener('click', evt => this.handleClick(evt, cb));
+    return this.style(elem);
+  }
+
+  style(elem) {
+    elem.style.height = '20px';
+    elem.style.width = '20px';
+    return elem;
+  }
+}
+
+class Rating extends BaseElement {
+  constructor(cb) {
+    super(...arguments);
+    this.element = this.render(cb);
+  }
+
+  render(cb, max = 5) {
+    const { document } = this.getWindow();
+    const fragment = document.createDocumentFragment();
+    const elem = document.createElement('hbox');
+    elem.id = 'star-rating-container';
+    for (let i = 0; i < max; i++) {
+      elem.appendChild(new RatingStar(max - i, cb).element);
+    }
+    fragment.appendChild(this.style(elem));
+    fragment.appendChild(this.renderSpacer());
+    return fragment;
+  }
+
+  renderSpacer() {
+    const { document } = this.getWindow();
+    const elem = document.createElement('spacer');
+    elem.flex = 66;
+    return elem;
+  }
+
+  style(elem) {
+    elem.style.marginBottom = '2px';
+    elem.style.mozBoxDirection = 'reverse';
+    elem.style.setProperty('-moz-box-direction', 'reverse', 'important');
+    return elem;
+  }
+}
+
+export default class Notification extends BaseElement {
+  constructor(options) {
+    super(...arguments);
+    this.id = uuid();
+    this.type = 'random';
+
+    this.notifyBox = null;
+    this.getSiteName().then(sitename => {
+      options.label = `How would you rate your experience on ${sitename}?`;
+      this.element = this.render(options);
+    });
+  }
+
+  promptedPing() {
+    const promptedPing = {
+      method: 'pulse-prompted',
+      id: this.id,
+      type: this.type
+    };
+    logger.log('Prompted', promptedPing);
+    sendEvent(promptedPing);
+  }
+
+  dismissedPing() {
+    const dismissedPing = {
+      method: 'pulse-dismissed',
+      id: this.id,
+      type: this.type
+    };
+    logger.log('Dismissed', dismissedPing);
+    sendEvent(dismissedPing);
+  }
+
+  dismiss(notifyBox, notification) {
+    notifyBox.removeNotification(notification);
+  }
+
+  openSurvey(surveyUrl, sentiment) {
+    storage.id[this.id] = tabs.activeTab;
+    tabs.open(new Uri(surveyUrl).query({ id: this.id, sentiment }).toString());
+  }
+
+  getParts(elem) {
+    const win = Services.wm.getMostRecentWindow('navigator:browser');
+    const details = win.document.getAnonymousElementByAttribute(
+      elem,
+      'anonid',
+      'details'
+    );
+    const closeButton = details.nextSibling;
+    const image = win.document.getAnonymousElementByAttribute(
+      elem,
+      'anonid',
+      'messageImage'
+    );
+    const text = win.document.getAnonymousElementByAttribute(
+      elem,
+      'anonid',
+      'messageText'
+    );
+    const spacer = text.nextSibling;
+    return { closeButton, details, image, spacer, text };
+  }
+
+  style(elem) {
+    const { closeButton, image, spacer, text } = this.getParts(elem);
+    closeButton.style.marginRight = '16px';
+    image.style.height = '24px';
+    image.style.margin = '8px';
+    image.style.marginRight = '6px';
+    image.style.width = '24px';
+    elem.style.backgroundColor = '#F1F1F1';
+    elem.style.color = '#333333';
+    elem.style.fontSize = '14px';
+    elem.style.padding = '0';
+    elem.style.setProperty('font-weight', '400', 'important');
+    spacer.flex = 0;
+    text.style.fontWeight = '400';
+    text.style.margin = '0';
+    return elem;
+  }
+
+  getSiteName() {
+    return new Promise(resolve => {
+      const worker = tabs.activeTab.attach({
+        contentScriptFile: data.url('sitename.js')
+      });
+      worker.port.on('send-sitename', sitename => {
+        resolve(sitename);
+      });
+      worker.port.emit('get-sitename', null);
+    });
+  }
+
+  render(instanceOptions) {
+    this.promptedPing();
+
+    const notifyBox = this.notifyBox = this.getWindow().gBrowser.getNotificationBox();
+    const options = Object.assign(
+      { priority: notifyBox.PRIORITY_INFO_LOW },
+      this.defaultOptions,
+      instanceOptions
+    );
+    const notification = notifyBox.appendNotification(
+      options.label,
+      `pulse-${new Date().getTime()}`,
+      options.image,
+      options.priority,
+      options.buttons,
+      options.callback
+    );
+    notification.appendChild(
+      new Rating(sentiment => {
+        this.dismiss(notifyBox, notification);
+        this.openSurvey(options.surveyUrl, sentiment);
+      }).element
+    );
+    notification.classList.add('heartbeat');
+    notification.persistence = options.persistence;
+
+    const { closeButton } = this.getParts(notification);
+    closeButton.addEventListener('click', () => {
+      this.dismissedPing();
+    });
+
+    return this.style(notification);
+  }
+}
+
+Notification.prototype.defaultOptions = {
+  label: 'How would you rate your experience on Mozilla.org?',
+  image: 'resource://pulse-at-mozilla-dot-com/webextension/icons/pulse-64.png',
+  buttons: [],
+  callback: () => {
+  },
+  persistence: 1
+};

--- a/src/lib/page-action.js
+++ b/src/lib/page-action.js
@@ -26,20 +26,28 @@ export default class PageAction {
     return new Uri('/survey/index.html').query(qs).toString();
   }
 
-  // Passed frame and tab IDs, create and show the pageAction popup for that
-  // tab if the frame is an outermost frame.
+  hide(frameId, tabId) {
+    if (frameId !== 0) {
+      return;
+    }
+    browser.pageAction.hide(tabId);
+  }
+
+  // Passed a tabs.Tab object, create and show the pageAction popup.
   create(frameId, tabId) {
-    if (frameId !== 0) return;
-    logger.log(`Creating page action for tab ${tabId}.`);
+    if (frameId !== 0) {
+      return;
+    }
+    logger.log(`Showing for tab ${tabId}`);
     this.getSitename(tabId).then(sitename => {
       browser.pageAction.setPopup({
         tabId,
         popup: this.makeSurveyUrl({ sitename })
       });
       browser.pageAction.show(tabId);
-      browser.tabs.executeScript(tabId, {
-        code: `${PULSE_STATUS} = true;`
-      }).then();
+      browser.tabs
+        .executeScript(tabId, { code: `${PULSE_STATUS} = true;` })
+        .then();
     });
   }
 
@@ -49,17 +57,15 @@ export default class PageAction {
     if (frameId !== 0) return;
     logger.log(`Destroying page action for tab ${tabId}.`);
     browser.pageAction.hide(tabId);
-    browser.tabs.executeScript(tabId, {
-      code: `${PULSE_STATUS} = false;`
-    }).then();
+    browser.tabs
+      .executeScript(tabId, { code: `${PULSE_STATUS} = false;` })
+      .then();
   }
-  
+
   // Passed a tab IDs, show the pageAction popup for that tab if it has already
   // been created.
   show(tabId) {
-    browser.tabs.executeScript(tabId, {
-      code: PULSE_STATUS
-    }).then(results => {
+    browser.tabs.executeScript(tabId, { code: PULSE_STATUS }).then(results => {
       if (results.length && !!results[0]) {
         logger.log(`Showing page action for tab ${tabId}.`);
         browser.pageAction.show(tabId);

--- a/src/lib/survey-url.js
+++ b/src/lib/survey-url.js
@@ -1,0 +1,12 @@
+import Uri from 'urijs';
+import { sendMessage } from '../webextension/lib/util';
+
+export default class SurveyUrl {
+  constructor() {
+    this.url = new Uri(window.location.href)
+      .pathname('/survey/index.html')
+      .query({})
+      .toString();
+    sendMessage('survey-url', this.url);
+  }
+}

--- a/src/measurements/index.js
+++ b/src/measurements/index.js
@@ -49,8 +49,8 @@ const logger = new Logger(
 // Passed the output from the survey, augments that data with each measurment
 // in MEASUREMENTS and returns a promise resolving to a Map containing the full
 // payload, ready for submission to telemetry.
-export default data => {
-  const survey = new Map(Object.entries(data));
+export default surveyData => {
+  const survey = new Map(Object.entries(surveyData));
   logger.log(`Collecting data for ${survey.get('id')}`);
   const tab = storage.id[survey.get('id')];
   survey.delete('id');

--- a/src/webextension/background.js
+++ b/src/webextension/background.js
@@ -1,4 +1,9 @@
 import HttpObserver from '../lib/http-observer';
 import PageAction from '../lib/page-action';
+import SurveyUrl from '../lib/survey-url';
 
-window.app = { httpObserver: new HttpObserver(), pageAction: new PageAction() };
+window.app = {
+  httpObserver: new HttpObserver(),
+  pageAction: new PageAction(),
+  surveyUrl: new SurveyUrl()
+};

--- a/src/webextension/survey/components/app.jsx
+++ b/src/webextension/survey/components/app.jsx
@@ -17,12 +17,6 @@ class App extends Component {
     // Ensure that optional fields are included in the payload, even if empty.
     const defaultValues = { details: '' };
 
-    // Generate a UUID, then send to the host SDK add-on so that it can
-    // associate a future submission with the correct tab and window.
-    defaultValues.id = uuid();
-    window.surveyId = defaultValues.id;
-    sendMessage('loaded', { id: defaultValues.id, type: 'user' });
-
     // Get `sentiment` and `type` from the querystring.
     const qs = new Uri(window.location.search).search(true);
     if (!qs.sitename) {
@@ -35,6 +29,15 @@ class App extends Component {
       defaultValues,
       qs
     );
+
+    // Generate a UUID, then send to the host SDK add-on so that it can
+    // associate a future submission with the correct tab and window.
+    if (!('id' in initialValues)) {
+      initialValues.id = uuid();
+      sendMessage('loaded', { id: initialValues.id, type: 'user' });
+    }
+    window.surveyId = initialValues.id;
+
     if ('sentiment' in initialValues) {
       initialValues.sentiment = parseInt(initialValues.sentiment, 10);
     }

--- a/src/webextension/survey/components/fields/details.jsx
+++ b/src/webextension/survey/components/fields/details.jsx
@@ -5,6 +5,7 @@ export default class DetailsField extends Component {
     const { input } = this.props;
     return (
       <div className="field field--details">
+        <label className="step" htmlFor={input.name}>3.</label>
         <label htmlFor={input.name} id={input.name}>Any other comments?</label>
         <textarea placeholder="Optional comments..." {...input} />
       </div>

--- a/src/webextension/survey/components/fields/reason.jsx
+++ b/src/webextension/survey/components/fields/reason.jsx
@@ -59,6 +59,7 @@ class ReasonField extends Component {
     const { input: { name } } = this.props;
     return (
       <div className="field field--reason">
+        <label className="step" htmlFor={name}>2.</label>
         <label htmlFor={name}>This page is:</label>
         {this.renderSelect()}
       </div>

--- a/src/webextension/survey/components/fields/sentiment.jsx
+++ b/src/webextension/survey/components/fields/sentiment.jsx
@@ -49,6 +49,7 @@ export default class SentimentField extends Component {
     const { input, sitename } = this.props;
     return (
       <div className="field field--sentiment">
+        <label className="step">1.</label>
         <label>
           How would you rate your experience on {sitename}?
         </label>

--- a/src/webextension/survey/components/survey.jsx
+++ b/src/webextension/survey/components/survey.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Field, reduxForm } from 'redux-form';
 
+import Header from './header.jsx';
 import Thanks from './thanks.jsx';
 import DetailsField from './fields/details.jsx';
 import SentimentField from './fields/sentiment.jsx';
@@ -37,6 +38,7 @@ class Survey extends Component {
     const { handleSubmit, initialValues: { sitename } } = this.props;
     return (
       <form onSubmit={handleSubmit}>
+        <Header subheader="User satisfaction survey" />
         <Field
           name="sentiment"
           component={SentimentField}
@@ -62,7 +64,10 @@ class Survey extends Component {
   }
 
   render() {
-    const { submitSucceeded } = this.props;
+    const { initialValues, pristine, submitSucceeded } = this.props;
+    if (pristine && initialValues.sentiment) {
+      this.addtl(true);
+    }
     if (submitSucceeded) {
       this.addtl(false);
       return <Thanks subheader="Thank you!" />;

--- a/src/webextension/survey/styles.scss
+++ b/src/webextension/survey/styles.scss
@@ -38,12 +38,13 @@ body {
 
 header {
   background-size: 32px;
+  display: none;
   margin-bottom: 16px;
   min-height: 32px;
 
   h1 {
-    font-size: 15px;
-    font-weight: 600;
+    font-size: 16px;
+    font-weight: 400;
     line-height: 1;
   }
 
@@ -243,3 +244,88 @@ select {
   }
 }
 
+@media all and (min-width: 351px) {
+  body {
+    width: auto;
+  }
+}
+
+@media all and (min-width: 640px) {
+  html {
+    align-items: center;
+    background: #F8EEE4;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+  }
+
+  body,
+  body.addtl--show {
+    box-shadow: 0 5px 12px rgba(0, 0, 0, 0.2);
+    font-size: 14px;
+    height: auto;
+    margin: 0 auto;
+    padding: 0;
+    width: 450px;
+  }
+
+  header {
+    display: block;
+    padding: 16px 16px 16px 64px;
+  }
+
+  .addtl {
+    height: auto;
+    position: static;
+  }
+
+  .addtl--fields {
+    border: 0;
+    box-shadow: none;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    width: auto;
+  }
+
+  .addtl--screen {
+    display: none;
+  }
+
+  .field {
+    padding-left: 64px;
+    position: relative;
+
+    + .field {
+      margin-top: 26px;
+    }
+  }
+
+  .step {
+    left: 34px;
+    position: absolute;
+    top: 0;
+  }
+
+  .field--reason {
+    margin-top: 18px;
+
+    .step {
+      top: 4px;
+    }
+  }
+
+  .thanks {
+    header {
+      margin-bottom: 0;
+    }
+
+    p {
+      margin: 0 16px;
+
+      + p {
+        margin: 16px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
TODO:

- [x] Style the survey for display outside of the `pageAction` popup.
- [x] Ensure data flow from survey loaded in a tab to telemetry.
- [ ] Actually randomly prompt users. To begin with, we'll do this by prompting at the first navigation event after a timestamp chosen between 18 and 36 hours after the previous one.

## Try it out

[pulse-14-heartbeat.zip](https://github.com/mozilla/pulse/files/866510/pulse-14-heartbeat.zip) (may need to rename to .xpi)

## Screenshots

<img width="1132" alt="screen shot 2017-03-01 at 6 50 21 pm" src="https://cloud.githubusercontent.com/assets/23885/23489766/7778b4d6-feb1-11e6-9063-00a58d554682.png">

<img width="643" alt="screen shot 2017-03-23 at 6 04 22 pm" src="https://cloud.githubusercontent.com/assets/23885/24275172/2b9e3f56-0ff3-11e7-9a1c-05d0c7383149.png">
