### PR TITLE
Collect e10s status and process count (closes #128).

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -147,7 +147,22 @@ Fired upon successful submission of the survey containing the survey data augmen
 - `trackingProtection`: a boolean indicating whether tracking protection is enabled.
 - `openTabs`: a number indicating the count of open tabs across the browser.
 - `openWindows`: a number indicating the count of open windows across the browser.
-- `e10s`: a number indicating the number of content processes, retrieved from `dom.ipc.processCount`.
+- `e10sStatus`: a number indicating the status of e10s in the browser. Known values:
+
+  * `0` - Enabled by user
+  * `1` - Enabled by default
+  * `2` - Disabled
+  * `3` - Not used
+  * `4` - Disabled by accessibility tools
+  * `5` - Disabled by lack of graphics hardware acceleration on Mac OS X
+  * `6` - Disabled by unsupported text input
+  * `7` - Disabled by add-ons
+  * `8` - Disabled forcibly
+  * `9` - Disabled by graphics hardware acceleration on Windows XP
+
+  The latest list of values can be found by inspecting `multiProcessStatus` in [`aboutSupport.properties`](https://dxr.mozilla.org/mozilla-central/source/toolkit/locales/en-US/chrome/global/aboutSupport.properties).
+
+- `e10sProcessCount`: a number indicating the number of content processes, retrieved from `dom.ipc.processCount`.
 - `hangs`: a TBD measurement of the number of hangs across the browser. Likely to be split into child and main processes.
 - `timestamp`: a number containing a Unix timestamp from which the page request began.
 - `hostname`: a string indicating the hostname of the page request, as reported by `window.location.hostname`.
@@ -178,11 +193,11 @@ Fired upon successful submission of the survey containing the survey data augmen
   * `xml_dtd`
   * `xmlhttprequest`
   * `xslt`
-  
+
   With one special value:
 
   * `all`: all requests of all types, summed.
-  
+
   Each value of the object contains three data points:
 
   * `num`: the number of requests of that type.
@@ -196,7 +211,7 @@ Fired upon successful submission of the survey containing the survey data augmen
 - `sessionSize`: the number of page visits in the session.
 - `sessionLength`: the number of milliseconds elapsed in a session.
 - `sessionTimerContentLoaded`: an [aggregation] of `timerContentLoaded` across the session.
-- `sessionTimerWindowLoad`: an [aggregation] of `timerWindowLoad` across the session. 
+- `sessionTimerWindowLoad`: an [aggregation] of `timerWindowLoad` across the session.
 - `sessionTimerFirstPaint`: an [aggregation] of `timerFirstPaint` across the session.
 - `sessionTimerFirstInteraction`: an [aggregation] of `timerFirstInteraction` across the session.
 - `sessionTimerFirstByte`: an [aggregation] of `timerFirstByte` across the session.
@@ -225,7 +240,8 @@ Fired upon successful submission of the survey containing the survey data augmen
   "trackingProtection": true,
   "openTabs": 11,
   "openWindows": 1,
-  "e10s": 3,
+  "e10sStatus": 1,
+  "e10sProcessCount": 4,
   "hangs": 0,
   "timestamp": 1485394950697,
   "hostname": "testpilot.firefox.com",

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import tabs from 'sdk/tabs';
 import { setTimeout } from 'sdk/timers';
 import { getMostRecentBrowserWindow } from 'sdk/window/utils';
 
+import { e10sStatus, e10sProcessCount } from './lib/e10s-status';
 import Logger from './lib/log';
 import Notification from './lib/notify';
 import sendEvent from './lib/metrics';
@@ -64,6 +65,8 @@ webext.startup().then(({ browser }) => {
         measure(msg.payload)
           .then(measurements => {
             const submittedPing = Object.assign(msg.payload, measurements, {
+              e10sStatus: e10sStatus(),
+              e10sProcessCount: e10sProcessCount(),
               method: 'pulse-submitted'
             });
             logger.log('Submitted', submittedPing);

--- a/src/lib/e10s-status.js
+++ b/src/lib/e10s-status.js
@@ -1,0 +1,20 @@
+import { Cc, Ci } from 'chrome';
+import { Services } from 'resource://gre/modules/Services.jsm';
+import { get as getPreference } from 'sdk/preferences/service';
+
+export function e10sStatus() {
+  try {
+    let e10sStatus = Cc['@mozilla.org/supports-PRUint64;1'].createInstance(
+      Ci.nsISupportsPRUint64
+    );
+    let appinfo = Services.appinfo.QueryInterface(Ci.nsIObserver);
+    appinfo.observe(e10sStatus, 'getE10SBlocked', '');
+    return e10sStatus.data;
+  } catch (e) {
+    return -1;
+  }
+}
+
+export function e10sProcessCount() {
+  return getPreference('dom.ipc.processCount', null);
+}


### PR DESCRIPTION
CC @sunahsuh because there's a change in the telemetry format here. The original `e10s` value was not being reported and was erroneously not marked as `Not yet implemented`.

An example of a full payload with this change from about:telemetry: https://gist.github.com/chuckharmston/1e587f81f2ff2b2e6cf0b2443f83581d