### PR TITLE
Hide step labels when viewed in popup (closes #141).

### DIFF
--- a/src/webextension/survey/styles.scss
+++ b/src/webextension/survey/styles.scss
@@ -244,6 +244,10 @@ select {
   }
 }
 
+label.step {
+  display: none;
+}
+
 @media all and (min-width: 351px) {
   body {
     width: auto;
@@ -301,7 +305,8 @@ select {
     }
   }
 
-  .step {
+  label.step {
+    display: block;
     left: 34px;
     position: absolute;
     top: 0;


### PR DESCRIPTION
<img width="766" alt="screen shot 2017-03-29 at 1 09 43 pm" src="https://cloud.githubusercontent.com/assets/23885/24469459/2915f6d8-1481-11e7-9eeb-b7ce36ac7f0b.png">

<img width="712" alt="screen shot 2017-03-29 at 1 09 46 pm" src="https://cloud.githubusercontent.com/assets/23885/24469463/2adbe7d4-1481-11e7-9930-f0e227bd7e7c.png">

<img width="1223" alt="screen shot 2017-03-29 at 1 10 23 pm" src="https://cloud.githubusercontent.com/assets/23885/24469468/2cf2bf16-1481-11e7-86f2-0cbafe171662.png">
