### PR TITLE
[WIP] Prompt users to rate their experience every 30 hours.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,11 @@ import self from 'sdk/self';
 import { storage } from 'sdk/simple-storage';
 import webext from 'sdk/webextension';
 import tabs from 'sdk/tabs';
-import { setTimeout } from 'sdk/timers';
 import { getMostRecentBrowserWindow } from 'sdk/window/utils';
 
 import { e10sStatus, e10sProcessCount } from './lib/e10s-status';
 import Logger from './lib/log';
-import Notification from './lib/notify';
+import NotificationWatcher from './lib/notify';
 import sendEvent from './lib/metrics';
 import measure from './measurements';
 
@@ -92,10 +91,6 @@ webext.startup().then(({ browser }) => {
       }
     }
   });
-  setTimeout(
-    () => {
-      new Notification({ surveyUrl: storage.surveyUrl });
-    },
-    5000
-  );
+
+  new NotificationWatcher();
 });


### PR DESCRIPTION
This is a WIP, putting out to get some thoughts on the interval.

For testing, the numbers are drastically reduced. You can watch the status by filtering on `pulse.sdk.lib.notify` in the browser console, which should look like this:

<img width="865" alt="screen shot 2017-03-30 at 11 51 54 am" src="https://cloud.githubusercontent.com/assets/23885/24516381/03edff58-1540-11e7-92d2-59b44cd18b32.png">
