### PR TITLE
Sends correct type with pulse-loaded and pulse-submitted pings (closes #169, #170).

### DIFF
--- a/src/lib/notify.js
+++ b/src/lib/notify.js
@@ -145,7 +145,9 @@ class Notification extends BaseElement {
     }
     storage.id[this.id] = tabs.activeTab;
     tabs.open(
-      new Uri(surveyUrl).query({ id: this.id, sentiment, sitename }).toString()
+      new Uri(surveyUrl)
+        .query({ id: this.id, type: 'random', sentiment, sitename })
+        .toString()
     );
   }
 

--- a/src/webextension/survey/components/app.jsx
+++ b/src/webextension/survey/components/app.jsx
@@ -34,8 +34,11 @@ class App extends Component {
     // associate a future submission with the correct tab and window.
     if (!('id' in initialValues)) {
       initialValues.id = uuid();
-      sendMessage('loaded', { id: initialValues.id, type: 'user' });
     }
+    sendMessage('loaded', {
+      id: initialValues.id,
+      type: initialValues.type || 'user'
+    });
     window.surveyId = initialValues.id;
 
     if ('sentiment' in initialValues) {


### PR DESCRIPTION
This fixes two bugs:

1. We weren't appropriately including the `type` in the `pulse-submitted` event on prompts (#169).
2. We weren't sending the `pulse-loaded` event when the survey came with a UUID (i.e. when opened from a prompt; #170).

Will cut a 1.1.1 release when this merges.