### PR TITLE
Store active tab before opening survey in new tab (closes #175).

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,11 @@
 import { PageMod } from 'sdk/page-mod';
 import self from 'sdk/self';
-import { storage } from 'sdk/simple-storage';
 import webext from 'sdk/webextension';
-import tabs from 'sdk/tabs';
 import { getMostRecentBrowserWindow } from 'sdk/window/utils';
 
-import { e10sStatus, e10sProcessCount } from './lib/e10s-status';
 import Logger from './lib/log';
+import handleMessage from './lib/messages';
 import NotificationWatcher from './lib/notify';
-import sendEvent from './lib/metrics';
-import measure from './measurements';
 
 const logger = new Logger('sdk.index', getMostRecentBrowserWindow().console);
 
@@ -26,71 +22,8 @@ webext.startup().then(({ browser }) => {
   logger.log('WebExtension startup');
 
   // Listen for messages from the WebExtension.
-  browser.runtime.onMessage.addListener(msg => {
-    switch (msg.type) {
-      // When the survey is loaded, associate the passed ID with the
-      // currently-active tab for future processing. Then send the pulse-loaded
-      // Telemetry ping.
-      case 'loaded': {
-        if (!storage.id) {
-          storage.id = {};
-        }
-        storage.id[msg.payload.id] = tabs.activeTab;
-        const loadedPing = {
-          method: 'pulse-loaded',
-          id: msg.payload.id,
-          type: msg.payload.type
-        };
-        logger.log('Loaded', loadedPing);
-        sendEvent(loadedPing);
-        break;
-      }
+  browser.runtime.onMessage.addListener(handleMessage);
 
-      // When the survey is unloaded without being submitted,
-      case 'unloaded': {
-        const unloadedPing = {
-          method: 'pulse-unloaded',
-          id: msg.payload.id,
-          type: msg.payload.type
-        };
-        logger.log('Unloaded', unloadedPing);
-        sendEvent(unloadedPing);
-        break;
-      }
-
-      // When a submission is received, augment it with measurements before
-      // submitting.
-      case 'submitted': {
-        measure(msg.payload)
-          .then(measurements => {
-            const submittedPing = Object.assign(msg.payload, measurements, {
-              e10sStatus: e10sStatus(),
-              e10sProcessCount: e10sProcessCount(),
-              method: 'pulse-submitted'
-            });
-            logger.log('Submitted', submittedPing);
-            sendEvent(submittedPing);
-            delete storage.id[msg.payload.id];
-          })
-          .catch(err => {
-            logger.log(err);
-          });
-        break;
-      }
-
-      //
-      case 'survey-url': {
-        logger.log('Received survey url', msg.payload);
-        storage.surveyUrl = msg.payload;
-        break;
-      }
-
-      default: {
-        logger.error('Unknown message type.', msg);
-        break;
-      }
-    }
-  });
-
+  // Start time for prompted feedback.
   new NotificationWatcher();
 });

--- a/src/lib/messages.js
+++ b/src/lib/messages.js
@@ -1,0 +1,91 @@
+import { storage } from 'sdk/simple-storage';
+import tabs from 'sdk/tabs';
+import { getMostRecentBrowserWindow } from 'sdk/window/utils';
+
+import measure from '../measurements';
+import { e10sProcessCount, e10sStatus } from './e10s-status';
+import Logger from './log';
+import sendEvent from './metrics';
+
+const logger = new Logger(
+  'sdk.lib.messages',
+  getMostRecentBrowserWindow().console
+);
+
+export const storeTab = uuid => {
+  // Associate a tab with the passed randomly-generated UUID. This allows us to
+  // reliably retrieve it later for measurement.
+  if (!storage.id) {
+    storage.id = {};
+  }
+  logger.log(Object.keys(storage.id));
+  if (uuid in storage.id) {
+    logger.log(`Not storing ${uuid}; already exists as ${storage.id[uuid].id}`);
+  } else {
+    logger.log(`Storing ${uuid} as ${tabs.activeTab.id}`);
+    storage.id[uuid] = tabs.activeTab;
+  }
+};
+
+export default msg => {
+  switch (msg.type) {
+    // When the survey is loaded, associate the passed ID with the
+    // currently-active tab for future processing. Then send the pulse-loaded
+    // Telemetry ping.
+    case 'loaded': {
+      storeTab(msg.payload.id);
+      const loadedPing = {
+        method: 'pulse-loaded',
+        id: msg.payload.id,
+        type: msg.payload.type
+      };
+      logger.log('Loaded', loadedPing);
+      sendEvent(loadedPing);
+      break;
+    }
+
+    // When the survey is unloaded without being submitted,
+    case 'unloaded': {
+      const unloadedPing = {
+        method: 'pulse-unloaded',
+        id: msg.payload.id,
+        type: msg.payload.type
+      };
+      logger.log('Unloaded', unloadedPing);
+      sendEvent(unloadedPing);
+      break;
+    }
+
+    // When a submission is received, augment it with measurements before
+    // submitting.
+    case 'submitted': {
+      measure(msg.payload)
+        .then(measurements => {
+          const submittedPing = Object.assign(msg.payload, measurements, {
+            e10sStatus: e10sStatus(),
+            e10sProcessCount: e10sProcessCount(),
+            method: 'pulse-submitted'
+          });
+          logger.log('Submitted', submittedPing);
+          sendEvent(submittedPing);
+          delete storage.id[msg.payload.id];
+        })
+        .catch(err => {
+          logger.log(err);
+        });
+      break;
+    }
+
+    //
+    case 'survey-url': {
+      logger.log('Received survey url', msg.payload);
+      storage.surveyUrl = msg.payload;
+      break;
+    }
+
+    default: {
+      logger.error('Unknown message type.', msg);
+      break;
+    }
+  }
+};

--- a/src/lib/notify.js
+++ b/src/lib/notify.js
@@ -11,6 +11,7 @@ import { getMostRecentBrowserWindow } from 'sdk/window/utils';
 
 import Logger from './log';
 import sendEvent from './metrics';
+import { storeTab } from './messages';
 
 const logger = new Logger(
   'sdk.lib.notify',
@@ -140,10 +141,6 @@ class Notification extends BaseElement {
   }
 
   openSurvey(surveyUrl, sentiment, sitename) {
-    if (!storage.id) {
-      storage.id = {};
-    }
-    storage.id[this.id] = tabs.activeTab;
     tabs.open(
       new Uri(surveyUrl)
         .query({ id: this.id, type: 'random', sentiment, sitename })
@@ -205,6 +202,7 @@ class Notification extends BaseElement {
 
   render(sitename, instanceOptions) {
     this.promptedPing();
+    storeTab(this.id);
 
     const notifyBox = this.notifyBox = this.getWindow().gBrowser.getNotificationBox();
     const options = Object.assign(


### PR DESCRIPTION
Originally, I'd tried storing the active tab immediately before opening the survey from the prompt. It appears that there was a race condition here; sometimes the tab stored was actually the one _in_ which the survey was opened, rather than the one _from_ which it was opened. This caused the measurement process to silently fail. The good news: no bad data was reported. The bad news: in these cases, no good data was reported.

This patch moves the storage of the tab from `openSurvey` to the time the prompt is rendered, ensuring that there is no race condition. After it's merged, I'll release a new version.

In the process of debugging this, I made a nice refactor (moving message handling into a library) that I kept. Minimal new code, just some shifting.
