### PR TITLE
define a text color whenever we define a background color

### DIFF
--- a/src/webextension/survey/styles.scss
+++ b/src/webextension/survey/styles.scss
@@ -61,6 +61,7 @@ textarea,
 button,
 select {
   background-color: #FFF;
+  color: black;
   border: 1px solid #B1B1B1;
   border-radius: 0;
   font: $font--default;
@@ -131,6 +132,7 @@ select {
 
 .addtl--screen {
   background: rgba(0, 0, 0, 0.1);
+  color: black;
   height: 100vh;
   left: 0;
   position: absolute;


### PR DESCRIPTION
This looks like the only two places where this happens (and one of
them is probably harmless, but it's hard to tell). Fixes #180.